### PR TITLE
Bundle in serf

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -71,15 +71,37 @@
                     ]
                 },
                 {
+                    "name" : "serf",
+                    "buildsystem": "simple",
+                    "build-commands": [
+                        "tar -xf scons-local-2.3.0.tar.gz",
+                        "python2 scons.py APR=/app/bin/apr-1-config APU=/app/bin/apu-1-config PREFIX=/app",
+                        "python2 scons.py install"
+                    ],
+                    "sources" : [
+                        {
+                            "type": "file",
+                            "url": "http://prdownloads.sourceforge.net/scons/scons-local-2.3.0.tar.gz",
+                            "sha256": "24c83b6067ce2b994a08d613add791633982e6198151ec8508829ae26293bff0"
+                        },
+                        {
+                            "type": "archive",
+                            "url": "https://www.apache.org/dist/serf/serf-1.3.9.tar.bz2",
+                            "sha256": "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc"
+                        }
+                    ]
+                },
+                {
                     "name": "subversion",
                     "config-opts" : [
-                        "--with-lz4=internal"
+                        "--with-lz4=internal",
+                        "--with-serf"
                     ],
                     "sources" : [
                         {
                             "type": "archive",
-                            "url": "http://apache.mirrors.spacedump.net/subversion/subversion-1.10.0.tar.bz2",
-                            "sha256": "2cf23f3abb837dea0585a6b0ebd70e80e01f95bddef7c1aa097c18e3eaa6b584"
+                            "url": "http://apache.mirrors.spacedump.net/subversion/subversion-1.10.2.tar.bz2",
+                            "sha256": "5b35e3a858d948de9e8892bf494893c9f7886782f6abbe166c0487c19cf6ed88"
                         }
                     ]
                 }
@@ -106,7 +128,7 @@
                 {
                     "type": "archive",
                     "url": "http://invisible-island.net/datafiles/release/diffstat.tar.gz",
-                    "sha256": "25359e0c27183f997b36c9202583b5dc2df390c20e22a92606af4bf7856a55ee"
+                    "sha256": "7f09183644ed77a156b15346bbad4e89c93543e140add9dab18747e30522591f"
                 }
             ]
         },


### PR DESCRIPTION
Compile svn with --with-serf so svn sources can be fetched over http(s), at the moment only the svn protocol is supported for the bundled svn.

Also addressed #8, but not entirely sure it's the right solution.