### PR TITLE
flatpak 1.0.1 and flatpak-builder 1.0.0

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -202,8 +202,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/flatpak/flatpak/releases/download/0.99.3/flatpak-0.99.3.tar.xz",
-                    "sha256" : "d3ab44c8174f9c2b69b09ac630d5d1987bfe529226d7eca6ac1c7d8f438fa671"
+                    "url" : "https://github.com/flatpak/flatpak/releases/download/1.0.1/flatpak-1.0.1.tar.xz",
+                    "sha256" : "c464efc3aeccd9a97e42fa3c2fda13fde59aca1aadb08ce7a9e27d9e9a7a5e24"
                 }
             ]
         },
@@ -212,8 +212,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/flatpak/flatpak-builder/releases/download/0.99.3/flatpak-builder-0.99.3.tar.xz",
-                    "sha256" : "93de343e09cc1e929234623e1b241e3a4330e76e7c18cccd3543f13d3ccb036b"
+                    "url" : "https://github.com/flatpak/flatpak-builder/releases/download/1.0.0/flatpak-builder-1.0.0.tar.xz",
+                    "sha256" : "858a5b2204f569e47fb6cb57f28f7a0dab9d6f7a5a73a7c2688e23c61bf8567b"
                 }
             ]
         },

--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -105,8 +105,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://invisible-island.net/datafiles/release/diffstat.tar.gz",
-                    "sha256": "25359e0c27183f997b36c9202583b5dc2df390c20e22a92606af4bf7856a55ee"
+                    "url": "https://invisible-island.net/datafiles/release/diffstat.tar.gz",
+                    "sha256": "7f09183644ed77a156b15346bbad4e89c93543e140add9dab18747e30522591f"
                 }
             ]
         },

--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -78,8 +78,8 @@
                     "sources" : [
                         {
                             "type": "archive",
-                            "url": "http://apache.mirrors.spacedump.net/subversion/subversion-1.10.0.tar.bz2",
-                            "sha256": "2cf23f3abb837dea0585a6b0ebd70e80e01f95bddef7c1aa097c18e3eaa6b584"
+                            "url": "http://apache.mirrors.spacedump.net/subversion/subversion-1.10.2.tar.bz2",
+                            "sha256": "5b35e3a858d948de9e8892bf494893c9f7886782f6abbe166c0487c19cf6ed88"
                         }
                     ]
                 }


### PR DESCRIPTION
Update flatpak and flatpak-builder, fix #8 as part of enabling local testing