### PR TITLE
Stop forwarding unnecesary FDs in fusermount-wrapper.sh

### DIFF
--- a/fusermount-wrapper.sh
+++ b/fusermount-wrapper.sh
@@ -6,4 +6,4 @@ else
     FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
 fi
 
-exec flatpak-spawn --host --forward-fd=1 --forward-fd=2 --forward-fd=3 $FD_ARGS fusermount "$@"
+exec flatpak-spawn --host $FD_ARGS fusermount "$@"


### PR DESCRIPTION
Following analysis from [1] we can conclude that explicit forwarding of fd1 and fd2 is redundant as they're always forwarded and unconditional forwarding of fd3 is at least unnecessary and may be even harmful therefore they should all be dropped especially when original author doesn't recall the need for them here [2].

Fixes https://github.com/flathub/org.flatpak.Builder/issues/42

[1] https://github.com/flatpak/flatpak-xdg-utils/issues/55#issuecomment-904021909
[2] https://github.com/flathub/org.flatpak.Builder/issues/42#issuecomment-911265906