### PR TITLE
Execute appstream-compose on the host

### DIFF
--- a/0001-Execute-appstream-util-on-the-host.patch
+++ b/0001-Execute-appstream-util-on-the-host.patch
@@ -1,13 +1,15 @@
-From 8e26769c4b6a266a704c6c9c16f79dced0540ebc Mon Sep 17 00:00:00 2001
+From c8d4e17e68784115783caba9d621f973bb661211 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bart=C5=82omiej=20Piotrowski?= <b@bpiotrowski.pl>
 Date: Tue, 25 Jan 2022 15:02:48 +0100
 Subject: [PATCH] Execute appstream-util on the host
 
 This should fix problems caused by the combination of flatpaked
-flatpak-builder and applications with session-bus permissions.
+flatpak-builder and applications with session-bus permissions,
+and compose errors caused by old appstream-glib releases.
 ---
- src/builder-main.c | 10 +---------
- 1 file changed, 1 insertion(+), 9 deletions(-)
+ src/builder-main.c     | 10 +---------
+ src/builder-manifest.c | 12 +++++-------
+ 2 files changed, 6 insertions(+), 16 deletions(-)
 
 diff --git a/src/builder-main.c b/src/builder-main.c
 index fb0c85ea..e874a66a 100644
@@ -37,6 +39,46 @@ index fb0c85ea..e874a66a 100644
                                            NULL,
                                            0,
                                            &error,
+diff --git a/src/builder-manifest.c b/src/builder-manifest.c
+index 2f954819..c1485f69 100644
+--- a/src/builder-manifest.c
++++ b/src/builder-manifest.c
+@@ -2301,11 +2301,6 @@ appstream_compose (GFile   *app_dir,
+   va_list ap;
+ 
+   args = g_ptr_array_new_with_free_func (g_free);
+-  g_ptr_array_add (args, g_strdup ("flatpak"));
+-  g_ptr_array_add (args, g_strdup ("build"));
+-  g_ptr_array_add (args, g_strdup ("--die-with-parent"));
+-  g_ptr_array_add (args, g_strdup ("--nofilesystem=host:reset"));
+-  g_ptr_array_add (args, g_file_get_path (app_dir));
+   g_ptr_array_add (args, g_strdup ("appstream-compose"));
+ 
+   va_start (ap, error);
+@@ -2314,7 +2309,7 @@ appstream_compose (GFile   *app_dir,
+   g_ptr_array_add (args, NULL);
+   va_end (ap);
+ 
+-  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
++  if (!flatpak_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
+     {
+       g_prefix_error (error, "ERROR: appstream-compose failed: ");
+       return FALSE;
+@@ -2751,10 +2746,13 @@ builder_manifest_cleanup (BuilderManifest *self,
+ 
+       if (self->appstream_compose && appdata_file != NULL)
+         {
++          g_autofree char *app_root_path = g_file_get_path (app_root);
++          g_autofree char *prefix_arg = g_strdup_printf ("--prefix=%s", app_root_path);
+           g_autofree char *basename_arg = g_strdup_printf ("--basename=%s", self->id);
++
+           g_print ("Running appstream-compose\n");
+           if (!appstream_compose (app_dir, error,
+-                                  self->build_runtime ?  "--prefix=/usr" : "--prefix=/app",
++                                  prefix_arg,
+                                   "--origin=flatpak",
+                                   basename_arg,
+                                   self->id,
 -- 
-2.34.1
+2.35.1
 


### PR DESCRIPTION
The freedesktopsdk runtime 21.08 ships too old appstream-glib for some
files, causing build failures before we even get to the validation.