### PR TITLE
Fix #112 - Handle http redirect on appstream-glib validate

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -116,7 +116,8 @@
                         "patches/appstream-glib-0004-Relax-validation-requirements-for-captions.patch",
                         "patches/appstream-glib-0005-Change-min.-paragraph-length-to-5-and-max.-number-of.patch",
                         "patches/appstream-glib-0006-Allow-hyperlinks-in-list-elements-and-paragraphs.patch",
-                        "patches/appstream-glib-curl-redirect.patch"
+                        "patches/appstream-glib-curl-redirect.patch",
+                        "patches/appstream-glib-curl-validate-redirect.patch"
                     ]
                 }
             ]

--- a/patches/appstream-glib-curl-validate-redirect.patch
+++ b/patches/appstream-glib-curl-validate-redirect.patch
@@ -1,0 +1,12 @@
+diff --git a/libappstream-glib/as-app-validate.c b/libappstream-glib/as-app-validate.c
+index a11c361..73382de 100644
+--- a/libappstream-glib/as-app-validate.c
++++ b/libappstream-glib/as-app-validate.c
+@@ -465,6 +465,7 @@ ai_app_validate_image_check (AsImage *im, AsAppValidateHelper *helper)
+ 	url = as_image_get_url (im);
+ 	g_debug ("checking %s", url);
+ 	(void)curl_easy_setopt(helper->curl, CURLOPT_URL, url);
++	(void)curl_easy_setopt(helper->curl, CURLOPT_FOLLOWLOCATION, 1);
+ 	(void)curl_easy_setopt(helper->curl, CURLOPT_ERRORBUFFER, errbuf);
+ 	(void)curl_easy_setopt(helper->curl,
+ 			       CURLOPT_WRITEFUNCTION,


### PR DESCRIPTION
Follow-up to #108


Close #112