### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -10,7 +10,12 @@
         "--allow=devel",
         "--talk-name=org.freedesktop.Flatpak",
         "--share=ipc",
-        "--filesystem=host",
+        "--filesystem=home",
+        "--filesystem=/media",
+        "--filesystem=/mnt",
+        "--filesystem=/run/media",
+        "--filesystem=/var/run/media",
+        "--filesystem=/var/mnt",
         "--share=network",
         "--filesystem=~/.local/share/flatpak",
         "--filesystem=/var/lib/flatpak"


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt