### PR TITLE
Add jq and gh to the manifest

### DIFF
--- a/gh.json
+++ b/gh.json
@@ -1,0 +1,33 @@
+{
+    "name": "gh",
+    "buildsystem": "simple",
+    "build-commands": [
+        "install -Dm755 bin/gh ${FLATPAK_DEST}/bin/gh"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "sha256": "0935fb1c783f65a0d43ebe4988dd117b27355704e230c386d9fd30774d729111",
+            "url": "https://github.com/cli/cli/releases/download/v2.43.1/gh_2.43.1_linux_amd64.tar.gz",
+            "only-arches": ["x86_64"],
+            "x-checker-data": {
+                "type": "json",
+                "url": "https://api.github.com/repos/cli/cli/releases/latest",
+                "url-query": ".assets[] | select(.name==\"gh_\" + $version + \"_linux_amd64.tar.gz\") | .browser_download_url",
+                "version-query": ".tag_name | sub(\"^v\"; \"\")"
+            }
+        },
+        {
+            "type": "archive",
+            "sha256": "5e27f664970c5608f83707dbcf81245604bb5dd3b3dc2164f25e8143ea0a9b11",
+            "url": "https://github.com/cli/cli/releases/download/v2.43.1/gh_2.43.1_linux_arm64.tar.gz",
+            "only-arches": ["aarch64"],
+            "x-checker-data": {
+                "type": "json",
+                "url": "https://api.github.com/repos/cli/cli/releases/latest",
+                "url-query": ".assets[] | select(.name==\"gh_\" + $version + \"_linux_arm64.tar.gz\") | .browser_download_url",
+                "version-query": ".tag_name | sub(\"^v\"; \"\")"
+            }
+        }
+    ]
+}

--- a/jq.json
+++ b/jq.json
@@ -1,0 +1,41 @@
+{
+    "name": "jq",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz",
+            "sha256": "5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72",
+            "x-checker-data": {
+                "type": "anitya",
+                "project-id": 13252,
+                "stable-only": true,
+                "url-template": "https://github.com/stedolan/jq/releases/download/jq-$version/jq-$version.tar.gz"
+            }
+        }
+    ],
+    "cleanup": [
+        "/share/doc",
+        "/share/man"
+    ],
+    "modules": [
+      {
+          "name": "oniguruma",
+          "config-opts": [
+              "--enable-posix-api"
+          ],
+          "sources": [
+              {
+                  "type": "archive",
+                  "url": "https://github.com/kkos/oniguruma/releases/download/v6.9.8/onig-6.9.8.tar.gz",
+                  "sha256": "28cd62c1464623c7910565fb1ccaaa0104b2fe8b12bcd646e81f73b47535213e",
+                  "x-checker-data": {
+                      "type": "anitya",
+                      "project-id": 11184,
+                      "stable-only": true,
+                      "url-template": "https://github.com/kkos/oniguruma/releases/download/v$version/onig-$version.tar.gz"
+                  }
+              }
+          ]
+      }
+    ]
+}

--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -37,6 +37,7 @@
     ],
     "modules": [
         "xvfb.json",
+        "jq.json",
         {
             "name": "dbus",
             "sources": [

--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -38,6 +38,7 @@
     "modules": [
         "xvfb.json",
         "jq.json",
+        "gh.json",
         {
             "name": "dbus",
             "sources": [


### PR DESCRIPTION
They're not useful to flatpak-builder package itself, but for the Docker images that are generated based on the manifest.