### PR TITLE
Propagate custom keys by default in appstream compose

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -78,7 +78,8 @@
                         {
                             "type": "patch",
                             "paths": [
-                                "patches/appstream-demotion-allowlist.patch"
+                                "patches/appstream-demotion-allowlist.patch",
+                                "patches/appstream-compose-default-propagate-custom.patch"
                             ]
                         }
                     ]

--- a/patches/appstream-compose-default-propagate-custom.patch
+++ b/patches/appstream-compose-default-propagate-custom.patch
@@ -1,0 +1,13 @@
+diff --git a/compose/asc-compose.c b/compose/asc-compose.c
+index 0b746ad9..a3050b0e 100644
+--- a/compose/asc-compose.c
++++ b/compose/asc-compose.c
+@@ -101,7 +101,7 @@ asc_compose_init (AscCompose *compose)
+ 	priv->flags = ASC_COMPOSE_FLAG_USE_THREADS | ASC_COMPOSE_FLAG_ALLOW_NET |
+ 		      ASC_COMPOSE_FLAG_VALIDATE | ASC_COMPOSE_FLAG_STORE_SCREENSHOTS |
+ 		      ASC_COMPOSE_FLAG_ALLOW_SCREENCASTS | ASC_COMPOSE_FLAG_PROCESS_FONTS |
+-		      ASC_COMPOSE_FLAG_PROCESS_TRANSLATIONS;
++		      ASC_COMPOSE_FLAG_PROCESS_TRANSLATIONS | ASC_COMPOSE_FLAG_PROPAGATE_CUSTOM;
+ 
+ 	/* the icon policy will initialize with default settings */
+ 	priv->icon_policy = asc_icon_policy_new ();


### PR DESCRIPTION
Context, `flathub::manifest` is not found in app-info with direct upload.

For upstream, a command-line option should be made and make flatpak-builder use it 🤔.