### PR TITLE
flatpak-builder-lint-deps: Add poetry-core

### DIFF
--- a/flatpak-builder-lint-deps.json
+++ b/flatpak-builder-lint-deps.json
@@ -4,6 +4,20 @@
   "build-commands": [],
   "modules": [
     {
+      "name": "python3-poetry-core",
+      "buildsystem": "simple",
+      "build-commands": [
+          "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"poetry-core>=1.0.0\" --no-build-isolation"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/a1/8d/85fcf9bcbfefcc53a1402450f28e5acf39dcfde3aabb996a1d98481ac829/poetry_core-1.9.0-py3-none-any.whl",
+          "sha256": "4e0c9c6ad8cf89956f03b308736d84ea6ddb44089d16f2adc94050108ec1f5a1"
+        }
+      ]
+    },
+    {
       "name": "python3-attrs",
       "buildsystem": "simple",
       "build-commands": [


### PR DESCRIPTION
This is needed by pip to install flatpak-builder-lint from git

Full-fledged poetry is to be purged from org.flatpak.Builder.BaseApp