### PR TITLE
Silence some validation errors from appstream-compose

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -157,7 +157,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flathub/flatpak-builder-lint",
-                    "commit": "513cb401b17a68800b3c5dbf6bde0000bdefc850"
+                    "commit": "210fbcdfb821b2a005d52d277ffb308a568834ea"
                 }
             ]
         }

--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -85,7 +85,8 @@
                             "type": "patch",
                             "paths": [
                                 "patches/appstream-demotion-allowlist.patch",
-                                "patches/appstream-compose-default-propagate-custom.patch"
+                                "patches/appstream-compose-default-propagate-custom.patch",
+                                "patches/asc-hint-tags-silence-some-vague-validation-errors.patch"
                             ]
                         }
                     ]

--- a/patches/asc-hint-tags-silence-some-vague-validation-errors.patch
+++ b/patches/asc-hint-tags-silence-some-vague-validation-errors.patch
@@ -1,0 +1,92 @@
+From cd5dd2c083e34456744d0fe7778efccadac67b18 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Sat, 20 Apr 2024 07:56:19 +0530
+Subject: [PATCH] asc-hint-tags: Silence some vague validation errors during
+ compose
+
+These are either covered by `appstreamcli validate` or by the linter's
+own checks and provide better and clearer error messages.
+
+The following are lowered to INFO:
+
+ * ancient-metadata
+ * metainfo-unknown-type
+ * icon-not-found
+ * metainfo-screenshot-but-no-media
+ * gui-app-without-icon
+ * no-metainfo
+ * no-valid-category
+---
+ compose/asc-hint-tags.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/compose/asc-hint-tags.c b/compose/asc-hint-tags.c
+index cf91318e..2dc0feef 100644
+--- a/compose/asc-hint-tags.c
++++ b/compose/asc-hint-tags.c
+@@ -57,7 +57,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "ancient-metadata",
+-	  AS_ISSUE_SEVERITY_WARNING,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The AppStream metadata should be updated to follow a more recent version of the specification.<br/>"
+ 	  "Please consult <a href=\"http://freedesktop.org/software/appstream/docs/chap-Quickstart.html\">the XML quickstart guide</a> for "
+ 	  "more information."
+@@ -99,7 +99,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "metainfo-unknown-type",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The component has an unknown type. Please make sure this component type is mentioned in the specification, and that the"
+ 	  "<code>type=</code> property of the component root-node in the MetaInfo XML file does not contain a spelling mistake."
+ 	},
+@@ -158,7 +158,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "icon-not-found",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The icon <em>{{icon_fname}}</em> was not found in the archive. This issue can have multiple reasons, "
+ 	  "like the icon being in a wrong directory or not being available in a suitable size (at least 64x64px). "
+ 	  "To make the icon easier to find, place it in <code>/usr/share/icons/hicolor/&lt;size&gt;/apps</code> and ensure the <code>Icon=</code> value"
+@@ -182,7 +182,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "metainfo-screenshot-but-no-media",
+-	  AS_ISSUE_SEVERITY_WARNING,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "A screenshot has been found for this component, but apparently it does not have any images or videos defined. "
+ 	  "The screenshot entry has been ignored."
+ 	},
+@@ -255,7 +255,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "gui-app-without-icon",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "The component is a GUI application (application which has a .desktop file for the XDG menu and <code>Type=Application</code>), "
+ 	  "but we could not find a matching icon for this application."
+ 	},
+@@ -278,7 +278,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "no-valid-category",
+-	  AS_ISSUE_SEVERITY_ERROR,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "This software component is no member of any valid category (note that custom categories and toolkit categories like 'Qt' or 'GTK' are ignored)."
+ 	},
+ 
+@@ -288,7 +288,7 @@ AscHintTagStatic asc_hint_tag_list[] =  {
+ 	},
+ 
+ 	{ "no-metainfo",
+-	  AS_ISSUE_SEVERITY_WARNING,
++	  AS_ISSUE_SEVERITY_INFO,
+ 	  "This software component is missing a <a href=\"https://freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent\">MetaInfo file</a> "
+ 	  "as metadata source.<br/>"
+ 	  "To synthesize suitable metadata anyway, we took some data from its desktop-entry file.<br/>"
+-- 
+2.44.0
+


### PR DESCRIPTION
These are too vague to provide any useful info or are covered by appstreamcli validate or the linter's own checks.