### PR TITLE
Add enviroment variable so that gdk-pixbuf can query cache from /app

### DIFF
--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -16,7 +16,8 @@
         "--share=network",
         "--filesystem=~/.local/share/flatpak",
         "--filesystem=/var/lib/flatpak",
-        "--filesystem=/tmp"
+        "--filesystem=/tmp",
+        "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
For https://github.com/flathub/org.flatpak.Builder.BaseApp/commit/17d551d49798b30e4e2846a53377ce2afe13d7a3