### PR TITLE
Update builder tools and make sure we don't break pip-generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,10 @@ jobs:
       run: |
         flatpak run --command=flathub-repro-checker org.flatpak.Builder//localtest --version
 
+    - name: Check if flatpak-pip-generator works
+      run: |
+       flatpak run --command=flatpak-pip-generator org.flatpak.Builder//localtest --help        
+
     - name: Sanity check the linter
       run: |
         flatpak run --command=flatpak-builder-lint org.flatpak.Builder//localtest --exceptions manifest org.flatpak.Builder.json

--- a/org.flatpak.Builder.json
+++ b/org.flatpak.Builder.json
@@ -175,7 +175,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flatpak/flatpak-builder-tools.git",
-                    "commit": "9ad6f3c4d58889d041bfc2a052719bea172664e3"
+                    "commit": "caca92bc6898ea40d6521b581fef2402ba3b3aae"
                 }
             ]
         },


### PR DESCRIPTION
Mostly so I can get https://github.com/flatpak/flatpak-builder-tools/commit/6f55d8b148ca8f2e01962938229d22aa3de6f017 so my build doesn't break